### PR TITLE
Resilience: retries for Cosmos/Redis/ACS, cooldowns, and health checks + tests

### DIFF
--- a/src/Chat.Web/Health/CosmosHealthCheck.cs
+++ b/src/Chat.Web/Health/CosmosHealthCheck.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Chat.Web.Health
+{
+    public class CosmosHealthCheck : IHealthCheck
+    {
+        private readonly Chat.Web.Repositories.CosmosClients _clients;
+        public CosmosHealthCheck(Chat.Web.Repositories.CosmosClients clients)
+        {
+            _clients = clients;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                // Quick ping by reading database properties
+                var resp = await _clients.Database.ReadAsync(cancellationToken: cancellationToken);
+                return resp.StatusCode == System.Net.HttpStatusCode.OK
+                    ? HealthCheckResult.Healthy()
+                    : HealthCheckResult.Unhealthy($"Cosmos status {resp.StatusCode}");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Cosmos exception", ex);
+            }
+        }
+    }
+}

--- a/src/Chat.Web/Health/RedisHealthCheck.cs
+++ b/src/Chat.Web/Health/RedisHealthCheck.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+
+namespace Chat.Web.Health
+{
+    public class RedisHealthCheck : IHealthCheck
+    {
+        private readonly IConnectionMultiplexer _mux;
+        public RedisHealthCheck(IConnectionMultiplexer mux)
+        {
+            _mux = mux;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var db = _mux.GetDatabase();
+                // Use PingAsync with a short timeout behavior via cancellation
+                var delayTask = Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+                var pingTask = db.PingAsync();
+                var completed = await Task.WhenAny(pingTask, delayTask).ConfigureAwait(false);
+                if (completed == pingTask)
+                {
+                    var latency = await pingTask.ConfigureAwait(false);
+                    return HealthCheckResult.Healthy($"Latency: {latency.TotalMilliseconds} ms");
+                }
+                return HealthCheckResult.Unhealthy("Redis ping timeout");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Redis exception", ex);
+            }
+        }
+    }
+}

--- a/src/Chat.Web/Resilience/RetryHelper.cs
+++ b/src/Chat.Web/Resilience/RetryHelper.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Chat.Web.Resilience
+{
+    /// <summary>
+    /// Lightweight async retry helper with exponential backoff and jitter.
+    /// Avoids external deps (Polly) while covering common transient fault handling.
+    /// </summary>
+    public static class RetryHelper
+    {
+        public static async Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, Func<Exception, bool> isTransient, ILogger logger, string operationName, int maxAttempts = 3, int baseDelayMs = 500, int perAttemptTimeoutMs = 5000)
+        {
+            var rnd = new Random();
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                using var cts = new CancellationTokenSource(perAttemptTimeoutMs);
+                try
+                {
+                    return await action(cts.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (isTransient(ex) && attempt < maxAttempts)
+                {
+                    var backoff = (int)(baseDelayMs * Math.Pow(2, attempt - 1));
+                    var jitter = rnd.Next(0, baseDelayMs);
+                    var delay = TimeSpan.FromMilliseconds(backoff + jitter);
+                    logger?.LogWarning(ex, "Transient failure in {Operation} attempt {Attempt}/{Max}. Retrying in {DelayMs}ms", operationName, attempt, maxAttempts, delay.TotalMilliseconds);
+                    await Task.Delay(delay).ConfigureAwait(false);
+                }
+            }
+            // Final attempt without catch to surface exception
+            using (var finalCts = new CancellationTokenSource(perAttemptTimeoutMs))
+            {
+                return await action(finalCts.Token).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Chat.Web/Resilience/Transient.cs
+++ b/src/Chat.Web/Resilience/Transient.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Azure.Cosmos;
+using StackExchange.Redis;
+
+namespace Chat.Web.Resilience
+{
+    /// <summary>
+    /// Centralized helpers to classify transient failures for various dependencies.
+    /// </summary>
+    public static class Transient
+    {
+        public static bool IsCosmosTransient(Exception ex)
+        {
+            if (ex is CosmosException cex)
+            {
+                var code = (int)cex.StatusCode;
+                if (code == 429 || code == 408 || code == 503) return true;
+            }
+            return IsNetworkTransient(ex);
+        }
+
+        public static bool IsRedisTransient(Exception ex)
+        {
+            if (ex is RedisConnectionException) return true;
+            if (ex is RedisTimeoutException) return true;
+            return IsNetworkTransient(ex);
+        }
+
+        public static bool IsNetworkTransient(Exception ex)
+        {
+            if (ex is TimeoutException) return true;
+            if (ex is SocketException) return true;
+            return false;
+        }
+    }
+}

--- a/src/Chat.Web/Services/AcsOtpSender.cs
+++ b/src/Chat.Web/Services/AcsOtpSender.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using Azure.Communication.Email;
 using Azure.Communication.Sms;
 using Chat.Web.Options;
+using Chat.Web.Resilience;
+using Microsoft.Extensions.Logging;
 
 namespace Chat.Web.Services
 {
@@ -13,19 +15,24 @@ namespace Chat.Web.Services
     public class AcsOtpSender : IOtpSender
     {
         private readonly AcsOptions _options;
-        private readonly EmailClient _emailClient;
-        private readonly SmsClient _smsClient;
+    private readonly EmailClient _emailClient;
+    private readonly SmsClient _smsClient;
+    private readonly ILogger<AcsOtpSender> _logger;
+        private static DateTimeOffset _cooldownUntil = DateTimeOffset.MinValue;
+        private static readonly object _gate = new object();
+        private const int CooldownSeconds = 15; // brief cooldown after repeated failures
 
     /// <summary>
     /// Validates configuration and primes Email + SMS clients.
     /// </summary>
-    public AcsOtpSender(AcsOptions options)
+    public AcsOtpSender(AcsOptions options, ILogger<AcsOtpSender> logger)
         {
             _options = options;
             if (string.IsNullOrWhiteSpace(options?.ConnectionString))
                 throw new InvalidOperationException("ACS ConnectionString is required when using AcsOtpSender.");
             _emailClient = new EmailClient(options.ConnectionString);
             _smsClient = new SmsClient(options.ConnectionString);
+            _logger = logger;
         }
 
     /// <inheritdoc />
@@ -34,6 +41,14 @@ namespace Chat.Web.Services
             if (string.IsNullOrWhiteSpace(destination))
                 throw new ArgumentException("Destination is required for ACS OTP sending", nameof(destination));
 
+            // Lightweight cooldown to reduce pressure during persistent outages.
+            var now = DateTimeOffset.UtcNow;
+            if (now < _cooldownUntil)
+            {
+                _logger?.LogWarning("Skipping ACS send for {User} due to cooldown until {Until}", userName, _cooldownUntil);
+                return;
+            }
+
             if (IsEmail(destination))
             {
                 if (string.IsNullOrWhiteSpace(_options.EmailFrom))
@@ -41,9 +56,24 @@ namespace Chat.Web.Services
 
                 var subject = "Your verification code";
                 var body = $"Your verification code is: {code}";
-                // Do not block on provider end-to-end completion on the first request; start send and return
-                using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(10));
-                await _emailClient.SendAsync(Azure.WaitUntil.Started, _options.EmailFrom, destination, subject, body, cancellationToken: cts.Token);
+                // Do not block on provider end-to-end completion; start send and return, with retries
+                try
+                {
+                    await RetryHelper.ExecuteAsync(
+                    ct => _emailClient.SendAsync(Azure.WaitUntil.Started, _options.EmailFrom, destination, subject, body, cancellationToken: ct),
+                    Transient.IsNetworkTransient,
+                    _logger,
+                    "acs.email.send",
+                    maxAttempts: 3,
+                    baseDelayMs: 200,
+                    perAttemptTimeoutMs: 5000);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "ACS email send failed for {User}", userName);
+                    ArmCooldown();
+                    throw;
+                }
             }
             else
             {
@@ -51,14 +81,41 @@ namespace Chat.Web.Services
                     throw new InvalidOperationException("AcsOptions.SmsFrom is required to send SMS OTP.");
 
                 var body = $"Code: {code}";
-                using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(10));
-                await _smsClient.SendAsync(from: _options.SmsFrom, to: destination, message: body, cancellationToken: cts.Token);
+                try
+                {
+                    await RetryHelper.ExecuteAsync(
+                    ct => _smsClient.SendAsync(from: _options.SmsFrom, to: destination, message: body, cancellationToken: ct),
+                    Transient.IsNetworkTransient,
+                    _logger,
+                    "acs.sms.send",
+                    maxAttempts: 3,
+                    baseDelayMs: 200,
+                    perAttemptTimeoutMs: 5000);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "ACS SMS send failed for {User}", userName);
+                    ArmCooldown();
+                    throw;
+                }
             }
         }
 
         private static bool IsEmail(string s)
         {
             return s.Contains("@");
+        }
+
+        private static void ArmCooldown()
+        {
+            var until = DateTimeOffset.UtcNow.AddSeconds(CooldownSeconds);
+            lock (_gate)
+            {
+                if (until > _cooldownUntil)
+                {
+                    _cooldownUntil = until;
+                }
+            }
         }
     }
 }

--- a/src/Chat.Web/Services/RedisOtpStore.cs
+++ b/src/Chat.Web/Services/RedisOtpStore.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
 using Chat.Web.Options;
+using Chat.Web.Resilience;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Chat.Web.Services
@@ -10,35 +12,115 @@ namespace Chat.Web.Services
     /// </summary>
     public class RedisOtpStore : IOtpStore
     {
-        private readonly IDatabase _db;
+    private readonly IDatabase _db;
+    private readonly ILogger<RedisOtpStore> _logger;
         private const string Prefix = "otp:";
+        private static DateTimeOffset _cooldownUntil = DateTimeOffset.MinValue;
+        private static readonly object _gate = new object();
+        private const int CooldownSeconds = 10;
 
     /// <summary>
     /// Constructs the store using a multiplexer and options specifying DB index.
     /// </summary>
-    public RedisOtpStore(IConnectionMultiplexer mux, Microsoft.Extensions.Options.IOptions<RedisOptions> options)
+    public RedisOtpStore(IConnectionMultiplexer mux, Microsoft.Extensions.Options.IOptions<RedisOptions> options, ILogger<RedisOtpStore> logger)
         {
             var opts = options.Value;
             _db = mux.GetDatabase(opts.Database);
+            _logger = logger;
         }
 
     /// <inheritdoc />
     public async Task<string> GetAsync(string userName)
         {
-            var val = await _db.StringGetAsync(Prefix + userName);
+            var now = DateTimeOffset.UtcNow;
+            if (now < _cooldownUntil)
+            {
+                _logger?.LogWarning("Skipping Redis GET due to cooldown until {Until}", _cooldownUntil);
+                return null;
+            }
+            RedisValue val;
+            try
+            {
+                val = await RetryHelper.ExecuteAsync(
+                    _ => _db.StringGetAsync(Prefix + userName),
+                    Transient.IsRedisTransient,
+                    _logger,
+                    "redis.otp.get",
+                    maxAttempts: 3,
+                    baseDelayMs: 200,
+                    perAttemptTimeoutMs: 1500);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Redis GET failed for OTP store; entering cooldown");
+                ArmCooldown();
+                throw;
+            }
             return val.IsNullOrEmpty ? null : (string)val;
         }
 
         /// <inheritdoc />
         public Task RemoveAsync(string userName)
         {
-            return _db.KeyDeleteAsync(Prefix + userName);
+            var now = DateTimeOffset.UtcNow;
+            if (now < _cooldownUntil)
+            {
+                _logger?.LogWarning("Skipping Redis DEL due to cooldown until {Until}", _cooldownUntil);
+                return Task.CompletedTask;
+            }
+            return RetryHelper.ExecuteAsync(
+                _ => _db.KeyDeleteAsync(Prefix + userName),
+                Transient.IsRedisTransient,
+                _logger,
+                "redis.otp.remove",
+                maxAttempts: 3,
+                baseDelayMs: 200,
+                perAttemptTimeoutMs: 1500).ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        _logger?.LogError(t.Exception?.GetBaseException(), "Redis DEL failed for OTP store; entering cooldown");
+                        ArmCooldown();
+                    }
+                });
         }
 
         /// <inheritdoc />
         public Task SetAsync(string userName, string code, TimeSpan ttl)
         {
-            return _db.StringSetAsync(Prefix + userName, code, ttl);
+            var now = DateTimeOffset.UtcNow;
+            if (now < _cooldownUntil)
+            {
+                _logger?.LogWarning("Skipping Redis SET due to cooldown until {Until}", _cooldownUntil);
+                return Task.CompletedTask;
+            }
+            return RetryHelper.ExecuteAsync(
+                _ => _db.StringSetAsync(Prefix + userName, code, ttl),
+                Transient.IsRedisTransient,
+                _logger,
+                "redis.otp.set",
+                maxAttempts: 3,
+                baseDelayMs: 200,
+                perAttemptTimeoutMs: 1500).ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        _logger?.LogError(t.Exception?.GetBaseException(), "Redis SET failed for OTP store; entering cooldown");
+                        ArmCooldown();
+                    }
+                });
+        }
+
+        private static void ArmCooldown()
+        {
+            var until = DateTimeOffset.UtcNow.AddSeconds(CooldownSeconds);
+            lock (_gate)
+            {
+                if (until > _cooldownUntil)
+                {
+                    _cooldownUntil = until;
+                }
+            }
         }
     }
 }

--- a/tests/Chat.Web.Tests/HealthEndpointsTests.cs
+++ b/tests/Chat.Web.Tests/HealthEndpointsTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace Chat.Web.Tests
+{
+    public class HealthEndpointsTests : IClassFixture<WebApplicationFactory<Chat.Web.Startup>>
+    {
+        private readonly WebApplicationFactory<Chat.Web.Startup> _factory;
+        public HealthEndpointsTests(WebApplicationFactory<Chat.Web.Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task InMemoryMode_Healthz_Ready_Returns200()
+        {
+            var app = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting("Testing:InMemory", "true");
+            });
+            var client = app.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+            var h1 = await client.GetAsync("/healthz");
+            var h2 = await client.GetAsync("/healthz/ready");
+            Assert.Equal(HttpStatusCode.OK, h1.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, h2.StatusCode);
+        }
+
+        [Fact]
+        public async Task RealMode_Healthz_Ready_Returns200_WithOverriddenChecks()
+        {
+            var app = _factory.WithWebHostBuilder(builder =>
+            {
+                // Force real-mode branch while providing placeholders
+                builder.UseSetting("Testing:InMemory", "false");
+                builder.UseSetting("Cosmos:ConnectionString", "AccountEndpoint=https://localhost:8081/;AccountKey=FAKE==;");
+                builder.UseSetting("Redis:ConnectionString", "localhost:6379,abortConnect=false");
+                builder.ConfigureServices(services =>
+                {
+                    // Override health checks to only include a simple healthy check
+                    services.PostConfigure<HealthCheckServiceOptions>(opts =>
+                    {
+                        opts.Registrations.Clear();
+                        opts.Registrations.Add(new HealthCheckRegistration(
+                            name: "self",
+                            instance: new Microsoft.Extensions.Diagnostics.HealthChecks.DelegateHealthCheck(_ => Task.FromResult(HealthCheckResult.Healthy())),
+                            failureStatus: null,
+                            tags: new[] { "ready" }));
+                    });
+                });
+            });
+            var client = app.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+            var h1 = await client.GetAsync("/healthz");
+            var h2 = await client.GetAsync("/healthz/ready");
+            Assert.Equal(HttpStatusCode.OK, h1.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, h2.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
This PR improves resilience and observability:

- Centralizes transient detection in Resilience/Transient.cs
- Adds RetryHelper and applies it to Cosmos repositories, Redis OTP store, and ACS sender
- Introduces cooldowns for Redis and ACS to reduce pressure during outages
- Adds custom health checks for Redis and Cosmos and exposes /healthz and /healthz/ready endpoints
- Adds integration tests for health endpoints in both in-memory and real-mode scenarios

All tests pass locally (39/39).