### PR TITLE
Chat.Web: enable-only login + Cosmos schema compatibility; docs: add Data schemas

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,8 +1,18 @@
 # Copy to .env.local and fill in your Azure resources
 # These map to Startup.cs expectations (Configuration["Cosmos:..."] and ["Redis:..."])
 
+## Microsoft Entra ID (OpenID Connect)
+AzureAd__Instance=https://login.microsoftonline.com/
+AzureAd__Domain=
+AzureAd__TenantId=
+AzureAd__ClientId=
+AzureAd__CallbackPath=/signin-oidc
+
+# Entra ID Group authorized to Admin.Web
+Authorization__ChatAdminGroupObjectId=
+
 # Cosmos DB
-Cosmos__ConnectionString=
+Cosmos__ConnectionString=''
 Cosmos__Database=chat
 Cosmos__UsersContainer=users
 Cosmos__RoomsContainer=rooms
@@ -15,7 +25,7 @@ Cosmos__MessagesContainer=messages
 
 
 # Redis (StackExchange.Redis)
-Redis__ConnectionString=
+Redis__ConnectionString=''
 
 # Azure SignalR connection string is picked up automatically by the Azure SignalR SDK via ConnectionStrings:Azure:SignalR or Azure__SignalR__ConnectionString if needed.
 # If your setup requires env-based binding, you can add:
@@ -23,6 +33,6 @@ Redis__ConnectionString=
 
 # Azure Communication Services (Email/SMS)
 # If provided, the app will send OTP using ACS instead of console
-Acs__ConnectionString=
+Acs__ConnectionString=''
 Acs__EmailFrom=
 Acs__SmsFrom=

--- a/src/Chat.Web/Controllers/RoomsController.cs
+++ b/src/Chat.Web/Controllers/RoomsController.cs
@@ -41,7 +41,7 @@ namespace Chat.Web.Controllers
 
             var rooms = _rooms.GetAll()
                 .Where(r => allowed.Contains(r.Name))
-                .Select(r => new RoomViewModel { Id = r.Id, Name = r.Name, Admin = r.Admin?.UserName })
+                .Select(r => new RoomViewModel { Id = r.Id, Name = r.Name })
                 .ToList();
 
             var json = JsonSerializer.Serialize(rooms, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
@@ -62,7 +62,7 @@ namespace Chat.Web.Controllers
             if (room == null || !allowed.Contains(room.Name))
                 return NotFound();
 
-            var vm = new RoomViewModel { Id = room.Id, Name = room.Name, Admin = room.Admin?.UserName };
+            var vm = new RoomViewModel { Id = room.Id, Name = room.Name };
             return Ok(vm);
         }
     }

--- a/src/Chat.Web/Models/ApplicationUser.cs
+++ b/src/Chat.Web/Models/ApplicationUser.cs
@@ -13,6 +13,10 @@ namespace Chat.Web.Models
         public string FullName { get; set; }
         public string Avatar { get; set; }
         /// <summary>
+        /// Whether this user is allowed to sign in. Defaults to true.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+        /// <summary>
         /// Email address for notification / identity enrichment.
         /// </summary>
         public string Email { get; set; }

--- a/src/Chat.Web/Models/Room.cs
+++ b/src/Chat.Web/Models/Room.cs
@@ -5,14 +5,10 @@ using System.Threading.Tasks;
 
 namespace Chat.Web.Models
 {
-    /// <summary>
-    /// Chat room aggregate; Admin designates the user allowed to rename or delete the room.
-    /// </summary>
     public class Room
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public ApplicationUser Admin { get; set; }
         public ICollection<Message> Messages { get; set; }
     }
 }

--- a/src/Chat.Web/Repositories/InMemoryRepositories.cs
+++ b/src/Chat.Web/Repositories/InMemoryRepositories.cs
@@ -12,7 +12,7 @@ namespace Chat.Web.Repositories
     {
         private readonly ConcurrentDictionary<string, ApplicationUser> _users = new();
         public IEnumerable<ApplicationUser> GetAll() => _users.Values;
-        public ApplicationUser GetByUserName(string userName) => _users.GetOrAdd(userName, u => new ApplicationUser { UserName = u, FullName = u });
+    public ApplicationUser GetByUserName(string userName) => _users.GetOrAdd(userName, u => new ApplicationUser { UserName = u, FullName = u, Enabled = true });
         public void Upsert(ApplicationUser user) => _users[user.UserName] = user;
     }
 

--- a/src/Chat.Web/ViewModels/RoomViewModel.cs
+++ b/src/Chat.Web/ViewModels/RoomViewModel.cs
@@ -15,6 +15,6 @@ namespace Chat.Web.ViewModels
         [RegularExpression(@"^\w+( \w+)*$", ErrorMessage = "Characters allowed: letters, numbers, and one space between words.")]
         public string Name { get; set; }
 
-        public string Admin { get; set; }
+    // Admin field removed
     }
 }


### PR DESCRIPTION
Summary
- Chat.Web
  - Login list shows only Enabled users; OTP start/verify reject disabled users.
  - Cosmos compatibility for Admin-authored data:
    - Users: accept `rooms` alias for `fixedRooms`; default `Enabled=true`; derive `defaultRoom` when missing.
    - Rooms: ignore `admin` field; tolerate non-numeric ids by deriving a stable numeric id for in-app use.
- Docs
  - ARCHITECTURE.md: add “Data schemas” section for User, Room, Message with JSON examples and Cosmos notes.

Details
- ApplicationUser: added `Enabled` flag (default true).
- InMemory/Cosmos Repositories: persist/read `Enabled`; read `rooms` or `fixedRooms`; derive `defaultRoom` if missing.
- Rooms mapping: removed admin; normalize id by stable numeric calculation when string ids encountered.
- AuthController: `/api/auth/users` returns enabled-only; OTP start/verify reject disabled users.
- RoomsController/RoomViewModel: project without admin; align with user FixedRooms filtering.
- ARCHITECTURE.md: documented schemas and Cosmos compatibility behaviors.

Notes
- No config changes needed for this feature. Ensure Redis__ConnectionString is set when not in Testing:InMemory.
- Messages TTL behavior unchanged; see Cosmos TTL section for details.

Validation
- Built solution locally and validated login shows only enabled users, with room visibility restored across schemas.

