### PR TITLE
fix: Ensure npm-generated assets included in deployment packages

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -50,7 +50,29 @@ jobs:
         Acs__SmsFrom: "+1234567890"
     
     - name: Publish application
-      run: dotnet publish src/Chat.Web/Chat.Web.csproj --configuration Release --output ./publish --no-build
+      run: dotnet publish src/Chat.Web/Chat.Web.csproj --configuration Release --output ./publish
+    
+    - name: Verify frontend assets in publish output
+      run: |
+        echo "Verifying Bootstrap version in published output..."
+        if (Test-Path "./publish/wwwroot/lib/bootstrap/css/bootstrap.min.css") {
+          $content = Get-Content "./publish/wwwroot/lib/bootstrap/css/bootstrap.min.css" -Raw
+          if ($content -match "v5\.(\d+)\.(\d+)") {
+            Write-Host "Bootstrap CSS found: v5.$($matches[1]).$($matches[2])"
+          } else {
+            Write-Host "Bootstrap CSS found but version not detected"
+          }
+        } else {
+          Write-Error "ERROR: Bootstrap CSS not found in publish output!"
+          exit 1
+        }
+        if (Test-Path "./publish/wwwroot/lib/microsoft-signalr/signalr.min.js") {
+          Write-Host "SignalR library found"
+        } else {
+          Write-Error "ERROR: SignalR library not found in publish output!"
+          exit 1
+        }
+      shell: pwsh
     
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -50,7 +50,29 @@ jobs:
         Acs__SmsFrom: "+1234567890"
     
     - name: Publish application
-      run: dotnet publish src/Chat.Web/Chat.Web.csproj --configuration Release --output ./publish --no-build
+      run: dotnet publish src/Chat.Web/Chat.Web.csproj --configuration Release --output ./publish
+    
+    - name: Verify frontend assets in publish output
+      run: |
+        echo "Verifying Bootstrap version in published output..."
+        if (Test-Path "./publish/wwwroot/lib/bootstrap/css/bootstrap.min.css") {
+          $content = Get-Content "./publish/wwwroot/lib/bootstrap/css/bootstrap.min.css" -Raw
+          if ($content -match "v5\.(\d+)\.(\d+)") {
+            Write-Host "Bootstrap CSS found: v5.$($matches[1]).$($matches[2])"
+          } else {
+            Write-Host "Bootstrap CSS found but version not detected"
+          }
+        } else {
+          Write-Error "ERROR: Bootstrap CSS not found in publish output!"
+          exit 1
+        }
+        if (Test-Path "./publish/wwwroot/lib/microsoft-signalr/signalr.min.js") {
+          Write-Host "SignalR library found"
+        } else {
+          Write-Error "ERROR: SignalR library not found in publish output!"
+          exit 1
+        }
+      shell: pwsh
     
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     
     - name: Publish build artifacts
       if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-      run: dotnet publish src/Chat.Web/Chat.Web.csproj --configuration Release --output ./publish --no-build
+      run: dotnet publish src/Chat.Web/Chat.Web.csproj --configuration Release --output ./publish
     
     - name: Upload build artifacts
       if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))


### PR DESCRIPTION
## Problem

After updating Bootstrap from 5.2.0 to 5.3.8 in PR #87, **staging environment** was correctly updated to Bootstrap 5.3.8, but **production remained on 5.2.0**.

### Root Cause

The CD workflows used `dotnet publish --no-build`, which relies on the previous `dotnet build` step's file list. However, npm-generated assets (copied to `wwwroot/lib/` by `npm run build:prod`) may not be properly tracked by the build system, causing them to be excluded from the publish output.

**Timeline:**
1. v0.9.4 tag created (Bootstrap 5.2.0)
2. Bootstrap updated to 5.3.8 (PR #87, merged to main)
3. Staging auto-deployed ✅ (has 5.3.8)
4. Production still on v0.9.4 ❌ (has 5.2.0)

The workflow bug meant that even when a new production tag is created, the deployment package might not include the updated Bootstrap files.

## Solution

### 1. Remove `--no-build` Flag
Removed `--no-build` from `dotnet publish` in all workflows:
- `.github/workflows/ci.yml`
- `.github/workflows/cd-staging.yml`
- `.github/workflows/cd-production.yml`

This ensures `dotnet publish` performs a fresh evaluation of all `wwwroot` content, including npm-generated libraries.

### 2. Add Verification Step
Added post-publish verification to both CD workflows to fail the build if frontend assets are missing:
```powershell
- name: Verify frontend assets in publish output
  run: |
    # Checks for Bootstrap CSS and extracts version
    # Checks for SignalR library
    # Fails build if either is missing
  shell: pwsh
```

## Changes

- ✅ Removed `--no-build` flag from `dotnet publish` (3 workflows)
- ✅ Added verification step to CD staging and production workflows
- ✅ Prevents deployment of incomplete packages
- ✅ Provides clear feedback if assets are missing

## Impact

- **Build time**: Minimal increase (~10-15s) - publish will rebuild, but tests already validated compilation
- **Reliability**: ✅ Ensures all npm dependencies are included in deployment
- **Visibility**: ✅ Verification step catches missing assets before deployment

## Testing

- [x] Verified `npm run build:prod` creates `wwwroot/lib/bootstrap/` and `wwwroot/lib/microsoft-signalr/`
- [x] Confirmed verification logic works with PowerShell on Windows runner
- [ ] Will be validated by CI workflow on this PR

## Next Steps

After this PR is merged:
1. Create new version tag (e.g., v0.9.5) to trigger production deployment
2. Production will receive Bootstrap 5.3.8 and SignalR 9.0.6 correctly
3. Verification step will confirm assets are present before deployment

## Related

- Fixes Bootstrap deployment issue (staging had 5.3.8, production had 5.2.0)
- Related to #85 (CD pipeline modernization)
- Builds on Bootstrap update from PR #87
- Addresses Issue #89 (code review - CI/CD workflows)

---

**Note:** This is a **bugfix for the deployment pipeline**. The Bootstrap update itself was already merged in PR #87; this ensures it actually makes it to production deployments.