### PR TITLE
Fix test documentation and CSP nonce test

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,13 +568,12 @@ All 55 tests passing ✅
 The project includes comprehensive test coverage across four test assemblies:
 
 ### Test Summary
-* **Total Tests**: 117 tests
+* **Total Tests**: 124 tests
 * **Status**: All passing ✅
 * **Test Projects**:
-  - `Chat.Tests` (80 tests): Unit tests including localization (55 tests), OTP hashing, configuration guards, unread notifications
-  - `Chat.DataSeed.Tests` (10 tests): Data seeding validation
-  - `Chat.IntegrationTests` (20 tests): End-to-end integration tests including OTP flow, rate limiting, room authorization, hub lifecycle
-  - `Chat.Web.Tests` (7 tests): Web-specific tests including security headers (CSP) and health endpoints
+  - `Chat.Tests` (93 tests): Unit tests including localization (55 tests), security (13 tests for log sanitization), OTP hashing, configuration guards, unread notifications
+  - `Chat.IntegrationTests` (22 tests): End-to-end integration tests including OTP flow, rate limiting, room authorization, hub lifecycle
+  - `Chat.Web.Tests` (9 tests): Web-specific tests including security headers (CSP), health endpoints
 
 ### Key Test Categories
 1. **Localization Tests** (55 tests in Chat.Tests)
@@ -583,7 +582,7 @@ The project includes comprehensive test coverage across four test assemblies:
    - Covers all 60+ resource keys across 9 cultures
    - Validates translation quality and completeness
 
-2. **Integration Tests** (20 tests in Chat.IntegrationTests)
+2. **Integration Tests** (22 tests in Chat.IntegrationTests)
    - `OtpAuthFlowTests`: Full OTP authentication workflow
    - `OtpAttemptLimitingTests`: Per-user failed attempt rate limiting (3 tests)
      - Validates blocking after N failed attempts
@@ -596,7 +595,7 @@ The project includes comprehensive test coverage across four test assemblies:
    - `MarkReadRateLimitingTests`: Read receipt rate limiting
    - `ImmediatePostAfterLoginTests`: REST fallback (feature-flagged)
 
-3. **Unit Tests** (25 tests in Chat.Tests, excluding localization)
+3. **Unit Tests** (38 tests in Chat.Tests, excluding localization)
    - `OtpHasherTests`: Argon2id hashing, salt, pepper verification
    - `ConfigurationGuardsTests`: Required configuration validation
    - `UnreadNotificationSchedulerTests`: Delayed notification logic

--- a/src/Chat.sln
+++ b/src/Chat.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chat.Tests", "..\tests\Chat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chat.IntegrationTests", "..\tests\Chat.IntegrationTests\Chat.IntegrationTests.csproj", "{1A3B8E4A-AC4E-4E31-9C1C-6E0C2E9F4A11}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chat.Web.Tests", "..\tests\Chat.Web.Tests\Chat.Web.Tests.csproj", "{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{1A3B8E4A-AC4E-4E31-9C1C-6E0C2E9F4A11}.Release|x64.Build.0 = Release|Any CPU
 		{1A3B8E4A-AC4E-4E31-9C1C-6E0C2E9F4A11}.Release|x86.ActiveCfg = Release|Any CPU
 		{1A3B8E4A-AC4E-4E31-9C1C-6E0C2E9F4A11}.Release|x86.Build.0 = Release|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Debug|x64.Build.0 = Debug|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Debug|x86.Build.0 = Debug|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Release|x64.ActiveCfg = Release|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Release|x64.Build.0 = Release|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Release|x86.ActiveCfg = Release|Any CPU
+		{F740D9E3-1A8A-4C0C-86F2-3F1A4D8EF1C4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
This PR fixes test documentation accuracy and resolves an intermittent test failure in the security headers tests.

## Changes

### 1. Fixed Intermittent CSP Nonce Test Failure
- **Test**: `CSP_Nonce_ShouldBeUnique_AndUsedInHTML` in `SecurityHeadersTests.cs`
- **Issue**: Test was intermittently failing when run with other tests
- **Fix**: 
  - Now fetches and checks content for both HTTP responses (not just one)
  - Added support for multiple nonce encoding patterns: HTML-encoded (`&quot;`), unencoded (`"`), and bare
  - More robust validation ensures nonce appears in corresponding HTML response

### 2. Updated README.md Test Documentation
- **Previous count**: 117 tests (inaccurate)
- **Actual count**: **124 tests** ✅

**Test breakdown updates**:
- `Chat.Tests`: 93 tests (was 80)
  - Added 13 new security tests for log sanitization
- `Chat.IntegrationTests`: 22 tests (was 20)
- `Chat.Web.Tests`: 9 tests (was 7)
- ❌ Removed reference to non-existent `Chat.DataSeed.Tests` (10 tests)
- Updated unit test count: 38 (was 25, excluding localization)

### 3. Added Chat.Web.Tests to Solution
- `Chat.Web.Tests` was not included in `src/Chat.sln`
- Now all 124 tests run via `dotnet test src/Chat.sln`
- Improves CI/CD integration and developer workflow

### 4. Cleanup
- Removed empty `tests/Chat.DataSeed.Tests/` folder (only contained build artifacts)

## Testing
All 124 tests passing ✅

```bash
dotnet test src/Chat.sln
# Test summary: total: 124, failed: 0, succeeded: 124
```

## Impact
- ✅ Fixes intermittent test failure
- ✅ Accurate documentation for contributors
- ✅ All tests now included in solution file
- ✅ Cleaner repository structure