### PR TITLE
[P0] Fix Bicep deployment parameter mismatch

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -199,7 +199,6 @@ jobs:
             --parameters acsDataLocation="${{ env.BICEP_ACS_DATA_LOCATION }}" \
             --parameters networkingResourceGroupName=${{ env.NETWORKING_RESOURCE_GROUP }} \
             --parameters otpPepper="${{ secrets.OTP_PEPPER }}" \
-            --parameters entraIdClientId="${{ secrets.ENTRA_ID_CLIENT_ID }}" \
             --parameters entraIdAllowedTenants=${{ secrets.ENTRA_ID_ALLOWED_TENANTS_JSON }} \
             --parameters entraIdAutomaticSsoEnable=${{ env.ENTRA_ID_AUTOMATIC_SSO_ENABLE }} \
             --parameters entraIdAutomaticSsoAttemptCookieName="${{ env.ENTRA_ID_AUTOMATIC_SSO_ATTEMPT_COOKIE_NAME }}" \
@@ -256,8 +255,6 @@ jobs:
             --parameters acsDataLocation="${{ env.BICEP_ACS_DATA_LOCATION }}" \
             --parameters networkingResourceGroupName=${{ env.NETWORKING_RESOURCE_GROUP }} \
             --parameters otpPepper="${{ secrets.OTP_PEPPER }}" \
-            --parameters entraIdClientId="${{ secrets.ENTRA_ID_CLIENT_ID }}" \
-            --parameters entraIdClientSecret="${{ secrets.ENTRA_ID_CLIENT_SECRET }}" \
             --parameters entraIdAllowedTenants=${{ secrets.ENTRA_ID_ALLOWED_TENANTS_JSON }} \
             --parameters entraIdAutomaticSsoEnable=${{ env.ENTRA_ID_AUTOMATIC_SSO_ENABLE }} \
             --parameters entraIdAutomaticSsoAttemptCookieName="${{ env.ENTRA_ID_AUTOMATIC_SSO_ATTEMPT_COOKIE_NAME }}" \

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -75,14 +75,6 @@ param entraIdFallbackEnableOtp bool = true
 @description('Allow OTP for unauthorized tenant users')
 param entraIdFallbackOtpForUnauthorizedUsers bool = false
 
-@description('Entra ID Client ID')
-@secure()
-param entraIdClientId string = ''
-
-@description('Entra ID Client Secret')
-@secure()
-param entraIdClientSecret string = ''
-
 @description('Optional Entra ID connection string (ClientId=...;ClientSecret=...)')
 @secure()
 param entraIdConnectionString string = ''


### PR DESCRIPTION
## Description
Fixes Bicep deployment validation error by removing unused `entraIdClientId` and `entraIdClientSecret` parameters. The application uses `entraIdConnectionString` via connection strings instead, so the separate ClientId/ClientSecret parameters were causing validation errors without adding value.

## Related Issues
Fixes #115

## Changes
- Removed `entraIdClientId` and `entraIdClientSecret` parameter passing from deploy-infrastructure workflow (both validate and deploy steps)
- Removed unused parameter declarations from `main.bicep`
- Kept only `entraIdConnectionString` which is actually used by the app via connection strings
- Cleaned up parameter passing in both validate and deploy workflow steps

## Testing
- [x] All tests pass
- [x] Added new tests for new features (N/A - infrastructure fix)
- [x] Tested locally (`az bicep build` validates successfully with only expected Redis API warnings)

## Checklist
- [x] Code follows project style
- [x] Documentation updated (N/A - workflow/infrastructure change)
- [x] No breaking changes (or documented)