### PR TITLE
fix: prepend DoNotReply@ to email sender domain output

### DIFF
--- a/infra/bicep/modules/communication.bicep
+++ b/infra/bicep/modules/communication.bicep
@@ -104,7 +104,7 @@ output emailDomainId string = emailDomain.id
 output emailDomainName string = emailDomain.name
 
 @description('The sender email address from Azure Managed Domain')
-output senderEmailAddress string = emailDomain.properties.mailFromSenderDomain
+output senderEmailAddress string = 'DoNotReply@${emailDomain.properties.mailFromSenderDomain}'
 
 @description('The resource ID of the Communication Service')
 output communicationServiceId string = communicationService.id


### PR DESCRIPTION
## Description

Fixes the email sender address format in Azure Communication Services Bicep module. The `emailDomain.properties.mailFromSenderDomain` property returns only the domain (e.g., `68a564b8-387e-4d46-80b5-58bafd775716.azurecomm.net`), but the App Service `Acs__EmailFrom` setting requires a full email address for sending OTP emails.

## Problem

The `senderEmailAddress` output was returning only the domain portion:
```bicep
output senderEmailAddress string = emailDomain.properties.mailFromSenderDomain
```

This resulted in `Acs__EmailFrom` being set to just the domain, which is invalid for email sending via Azure Communication Services.

## Solution

Modified the output to construct a full email address:
```bicep
output senderEmailAddress string = 'DoNotReply@${emailDomain.properties.mailFromSenderDomain}'
```

Now returns the proper format: `DoNotReply@68a564b8-387e-4d46-80b5-58bafd775716.azurecomm.net`

## Changes

- **`infra/bicep/modules/communication.bicep`**: Updated `senderEmailAddress` output to prepend "DoNotReply@" to the domain

## Testing

- ✅ Bicep validation passed for `communication.bicep`
- ✅ Bicep validation passed for `main.bicep` (full template compilation)
- ⏳ Infrastructure deployment testing pending

## Related Issues

Follows up on PR #128 which added Email Service with Azure Managed Domain.

## Checklist

- [x] Code follows project style
- [x] Bicep templates validated
- [x] No breaking changes
- [x] Commit message follows conventional commits format