### PR TITLE
fix: make UnreadNotificationScheduler optional in ChatHub

### DIFF
--- a/src/Chat.Web/Hubs/ChatHub.cs
+++ b/src/Chat.Web/Hubs/ChatHub.cs
@@ -47,13 +47,13 @@ namespace Chat.Web.Hubs
             Repositories.IRoomsRepository rooms,
             ILogger<ChatHub> logger,
             Services.IInProcessMetrics metrics,
-            Services.UnreadNotificationScheduler unreadScheduler,
             Services.IMarkReadRateLimiter markReadRateLimiter,
             Services.IPresenceTracker presenceTracker,
             IStringLocalizer<Resources.SharedResources> localizer,
             HealthCheckService healthCheckService,
             Services.ITranslationJobQueue translationQueue,
-            Microsoft.Extensions.Options.IOptions<Options.TranslationOptions> translationOptions)
+            Microsoft.Extensions.Options.IOptions<Options.TranslationOptions> translationOptions,
+            Services.UnreadNotificationScheduler unreadScheduler = null)
         {
             _users = users;
             _messages = messages;


### PR DESCRIPTION
## Description
Fixes SignalR connection error by making UnreadNotificationScheduler an optional dependency in ChatHub constructor.

## Related Issues
Resolves runtime error: "Unable to resolve service for type 'UnreadNotificationScheduler' while attempting to activate 'ChatHub'"

## Changes
- Moved `unreadScheduler` parameter to end of constructor with default `null` value
- Made it optional since the service is currently disabled in Startup.cs
- No other code changes needed - already uses null-conditional operators (`?.`)

## Testing
- [x] All tests pass (170/170)
- [x] Tested locally - SignalR connection now works
- [x] No new tests needed (existing null-safe code)

## Checklist
- [x] Code follows project style
- [x] Documentation not needed (internal fix)
- [x] No breaking changes (backward compatible - optional parameter)