### PR TITLE
fix: wire translation subscription key in app service

### DIFF
--- a/infra/bicep/modules/app-service.bicep
+++ b/infra/bicep/modules/app-service.bicep
@@ -303,8 +303,15 @@ var appSettingsAllowedTenants = [for (i, tenantId) in entraIdAllowedTenants: {
   value: tenantId
 }]
 
+var translationAppSettingArray = translationSubscriptionKey != '' ? [
+  {
+    name: 'Translation__SubscriptionKey'
+    value: translationSubscriptionKey
+  }
+] : []
+
 // Final app settings array
-var allAppSettings = concat(baseAppSettings, appSettingsAllowedTenants)
+var allAppSettings = concat(baseAppSettings, appSettingsAllowedTenants, translationAppSettingArray)
 
 // Base connection strings
 var baseConnectionStrings = [
@@ -335,14 +342,6 @@ var baseConnectionStrings = [
   }
 ]
 
-var translationConnectionStringArray = translationSubscriptionKey != '' ? [
-  {
-    name: 'Translation__SubscriptionKey'
-    connectionString: translationSubscriptionKey
-    type: 'Custom'
-  }
-] : []
-
 var entraConnectionStringArray = entraIdConnectionString != '' ? [
   {
     name: 'EntraId'
@@ -351,7 +350,7 @@ var entraConnectionStringArray = entraIdConnectionString != '' ? [
   }
 ] : []
 
-var allConnectionStrings = concat(baseConnectionStrings, translationConnectionStringArray, entraConnectionStringArray)
+var allConnectionStrings = concat(baseConnectionStrings, entraConnectionStringArray)
 
 // ==========================================
 // App Service Plan


### PR DESCRIPTION
## Description
Fixes Azure App Service translation configuration by wiring the Translator subscription key in a way that binds correctly on Linux.

## Related Issues
Fixes #

## Changes
- Move `Translation__SubscriptionKey` to App Settings in Bicep (instead of Connection Strings)
- Keep config fallback minimal and Custom-only (no MySql/PostgreSQL connection string prefixes)

## Testing
- [x] All tests pass
- [ ] Added new tests for new features
- [x] Tested locally

## Checklist
- [x] Code follows project style
- [ ] Documentation updated
- [x] No breaking changes (or documented)
