### PR TITLE
fix: scope CD workflow token permissions per job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,6 +26,8 @@ jobs:
   determine-environment:
     name: Determine Environment
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       environment: ${{ steps.set-env.outputs.environment }}
       is-release: ${{ steps.set-env.outputs.is-release }}


### PR DESCRIPTION
## Description
Add explicit job-level `permissions` to the CD workflow to satisfy the security check: "Workflow does not contain permissions" and ensure `GITHUB_TOKEN` is least-privilege.

## Related Issues
N/A

## Changes
- Add `permissions: contents: read` to `determine-environment` job (other jobs already define permissions)

## Testing
- [ ] All tests pass
- [ ] Added new tests for new features
- [ ] Tested locally

## Checklist
- [x] Code follows project style
- [ ] Documentation updated
- [x] No breaking changes (or documented)
